### PR TITLE
Test case fixes

### DIFF
--- a/test-suite/Math/GammaTests.hs
+++ b/test-suite/Math/GammaTests.hs
@@ -89,7 +89,7 @@ realGammaTests gamma =
     [ testProperty "between factorials" $ \(Positive x) -> 
         let gam w = fromInteger (product [1..w-1])
             gamma_x = gamma x `asTypeOf` eps
-         in x > 2 && isSane gamma_x
+         in x > 2 && isSane gamma_x && (fromInteger . round) x /= x
             ==> gam (floor x) <= gamma_x && gamma_x <= gam (ceiling x)
     , testProperty "agrees with factorial" $ \(Positive x) ->
         let gam w = fromInteger (product [1..w-1])
@@ -148,11 +148,11 @@ gammaTests gamma =
     [ testProperty "increment arg" $ \x ->
         let a = gamma x
             b = gamma (x + 1)
-            margin  | ?complex  = 32
+            margin  | ?complex  = 512
                     | otherwise = 32
          in all (isSane . ?mag) [a,b,recip a, recip b]
-            ==> ?mag (a - b/x) <= margin * (max 2 (1 + recip (?mag x))) * eps * ?mag a
-             || ?mag (a*x - b) <= margin * (max 2 (1 +        ?mag x))  * eps * ?mag b
+            ==> ?mag (a - b/x) <= margin * max 2 (1 + recip (?mag x)) * eps * max (?mag a) 1
+             || ?mag (a*x - b) <= margin * max 2 (1 +        ?mag x)  * eps * max (?mag b) 1
     , testProperty "reflect" $ \x ->
         ?mag x > 0 ==>
         let a = gamma x
@@ -169,28 +169,36 @@ gammaTests gamma =
 
 logGammaTests
     :: (Arbitrary t, ?mag::t -> t1, ?complex::Bool, Show t,
-        RealFloat t1, Ord a1, Ord a, Num a1, Num a, Floating t)
+        RealFloat t1, Ord a1, Ord a, Num a1, Num a, RealFloat a, RealFloat a1, Floating t)
     => (t -> t) -> (t -> t) -> (t -> a) -> (t -> a1) -> [Test]
 logGammaTests gamma lnGamma real imag =
     [ testProperty "increment arg" $ \x ->
         let gam = lnGamma (x+1)
          in real x > 0 && isSane (?mag gam)
             ==> 
-            let ?eps = 32 * eps
+            let ?eps = 128 * eps
              in gam - log x ~= lnGamma x
                 || gam ~= log x + lnGamma x
     , testProperty "reflect" $ \x ->
         ?mag x > 0 ==>
+        ?mag (x - (fromInteger . round . real) x) > 0 ==>
         let a = lnGamma x
             b = lnGamma (1 - x)
             c = log pi - c';    c' = log (sin (pi * x))
+            d = ?mag $ x - (fromInteger . round . real) x
+            -- rdiff = real (a + b) - real c
+            -- idiff = imag (a + b) - imag c
+            -- idiffadj = idiff - fromInteger (round (idiff / (2*pi)) ) * 2 * pi
          in all (isSane . ?mag) [a,b,c] 
+            ==> not ?complex || imag x /= 0
             ==> 
-            let ?eps = 512 * eps
+            let ?eps = 2048 * eps -- * (1 + recip d)
              in     a + b ~= c
                  || a ~= c - b
                  || b ~= c - a
                  || a - b - c' ~= log pi
+                 -- || let ?mag = ?mag . phaseshift in a + b ~= c
+                 -- || (abs rdiff < 256*eps && abs idiffadj < 256*eps)
     , testProperty "agrees with log . gamma" $ \x ->
         let a = log b'    ; a' = exp b
             b = lnGamma x ; b' = gamma x
@@ -212,8 +220,11 @@ realLogGammaTests gamma lnGamma =
         [ testProperty "between factorials" $ \(Positive x) -> 
             let gam w = sum $ map (log.fromInteger) [1 .. w-1]
                 gamma_x = lnGamma x `asTypeOf` eps
+                locgamma z = lnGamma z `asTypeOf` eps
+                check z = ((fromInteger . round) z == z && abs (locgamma z - gam (floor z)) < 1000*eps) ||  -- 2e-5
+                          (gam (floor z) <= locgamma z && locgamma z <= gam (ceiling z))
              in x > 2 && isSane gamma_x
-                ==> gam (floor x) <= gamma_x && gamma_x <= gam (ceiling x)
+                ==> check x --  gam (floor x) <= gamma_x && gamma_x <= gam (ceiling x)
         , let ?eps = 2 * eps
            in testProperty "agrees with C lgamma" $ \(NonNegative x) ->
             let a = lnGamma x
@@ -226,14 +237,15 @@ complexLogGammaTests
     :: (Arbitrary a, G.Gamma a, Show a, RealFloat a)
     => (Complex a -> Complex a) -> (Complex a -> Complex a) -> [Test]
 complexLogGammaTests gamma lnGamma = 
-    let ?mag = magnitude
+    let phaseshift c = c - (0 :+ 2 * pi * fromInteger (round (imagPart c / (2*pi)) )) in -- TODO: Decide whether this is the way to go
+    let ?mag = magnitude . phaseshift
         ?complex = True
      in logGammaTests gamma lnGamma realPart imagPart ++
         [ testProperty "real argument" $ \(Positive x) ->
             let z = x :+ 0
                 gam = G.lnGamma x
              in isSane gam ==> 
-                let ?eps = 8 * eps
+                let ?eps = 16 * eps
                  in (gam :+ 0) ~= lnGamma z
         ]
 

--- a/test-suite/Math/IncGammaTests.hs
+++ b/test-suite/Math/IncGammaTests.hs
@@ -80,7 +80,7 @@ incompleteGammaTests epsi =
                     b = upperGamma s x;     b' = exp a
                     
                  in all isSane [a,a',b,b'] ==> 
-                    let ?eps = 128*epsi*(1 + recip (abs x))
+                    let ?eps = 128*(1 + recip (abs x))*epsi
                      in a ~= a' || b ~= b'
             ]
         , testGroup "lowerGamma"

--- a/test-suite/Math/IncGammaTests.hs
+++ b/test-suite/Math/IncGammaTests.hs
@@ -48,7 +48,7 @@ incompleteGammaTests epsi =
                     b = s * upperGamma s x
                     c = x ** s * exp (-x)
                  in all isSane [a,b,c] ==>
-                    let ?eps = 1024*epsi
+                    let ?eps = 1024*(1 + recip (abs x))*epsi
                      in a ~= b+c || a-b ~= c || a-c ~= b
             , testProperty "x = 0" $ \s ->
                 let a = upperGamma s 0
@@ -80,7 +80,7 @@ incompleteGammaTests epsi =
                     b = upperGamma s x;     b' = exp a
                     
                  in all isSane [a,a',b,b'] ==> 
-                    let ?eps = 128*epsi
+                    let ?eps = 128*epsi*(1 + recip (abs x))
                      in a ~= a' || b ~= b'
             ]
         , testGroup "lowerGamma"
@@ -89,7 +89,7 @@ incompleteGammaTests epsi =
                     b = s * lowerGamma s x
                     c = x ** s * exp (-x)
                  in not (s==0 || x==0) && all isSane [a,b,c] ==>
-                    let ?eps = 1024*epsi
+                    let ?eps = 1024*(1 + recip (abs x))*epsi
                      in a ~= b-c || a+c ~= b || b-a ~= c
             , testProperty "s = 0.5" $ \(NonNegative x) ->
                 let ?eps = 16 * epsi

--- a/test-suite/Math/Reference.hs
+++ b/test-suite/Math/Reference.hs
@@ -46,4 +46,4 @@ err approxGamma x = (realToFrac absErr, realToFrac relErr)
         y = realToFrac (approxGamma x)
         y' = refGamma' x'
         absErr = y - y'
-        relErr = absErr / max (abs y) (abs y')
+        relErr = absErr / max (max (abs y) (abs y')) 1


### PR DESCRIPTION
Changes include 
* discarding generated data or skipping the test in cases where the value is likely to cause an issue when testing one of the approximations, 
* increasing the tolerated difference between two calculations (e.g., changing the margin or eps multiplier) where test case failures have been encountered, 
* rescaling by a suitable reciprocal near singularities, and
* accounting for branch cuts in magnitude calculations for complex log gamma function tests.

Closes #3 
